### PR TITLE
nueva opcion client = true al testear apis de clientes

### DIFF
--- a/lib/api-test.js
+++ b/lib/api-test.js
@@ -1,11 +1,17 @@
 'use strict';
 
 const { Dispatcher } = require('@janiscommerce/api');
+const ActiveClient = require('@janiscommerce/active-client');
 
 const assert = require('assert');
 const sandbox = require('sinon').createSandbox();
 
 const APITestError = require('./api-test-error');
+
+const defaultClient = {
+	id: 1,
+	name: 'defaultClient'
+};
 
 class APITest {
 
@@ -141,8 +147,14 @@ class APITest {
 		api.cookies = rule.request.cookies || {};
 		api.endpoint = rule.request.endpoint;
 
-		if(rule.client)
-			api.client = rule.client;
+		if(rule.client) {
+
+			const myClient = { ...(rule.client === true ? defaultClient : rule.client) };
+
+			ActiveClient.inject(myClient);
+
+			api.client = myClient;
+		}
 
 		return api;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/api-test",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -112,9 +112,9 @@
       }
     },
     "@janiscommerce/active-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@janiscommerce/active-client/-/active-client-1.2.0.tgz",
-      "integrity": "sha512-Q7E98bG7CSNUGJXRkPl3i/LvJm0GNb+mtZUwEjUVG4hlTfol9wHOWPc3DMDDPE69j/AJu52fdeOo3nyqivybdQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/active-client/-/active-client-1.2.1.tgz",
+      "integrity": "sha512-fmxSBjdNc2U23G3fCBhRihSlS2dfqcLvdUPGL5CgUBH1xxexoJCW9vZ3+HCzhwwzDFPVfaTEMOFXOxvKIPtIOw==",
       "requires": {
         "@janiscommerce/model": "^1.0.0",
         "@janiscommerce/settings": "^1.0.0"
@@ -151,9 +151,9 @@
       }
     },
     "@janiscommerce/model": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@janiscommerce/model/-/model-1.1.1.tgz",
-      "integrity": "sha512-YzExl+9bYpqnfjpMfqDYgfpXi058A/qItpBPLQR83skuqGSyVVmDDuEDiXbwUssVJf3YhpI2DOoiKSfAMSsPPw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/model/-/model-1.2.0.tgz",
+      "integrity": "sha512-5W6CMj5o6lmYckAk15ARLFoFrYBdmHEQ5IHCokU24wug49K8zcbv0Zx7WTe50I7Q1mMS4HwYo6fe6F4AhGe/bA==",
       "requires": {
         "@janiscommerce/database-dispatcher": "^1.3.3",
         "@janiscommerce/settings": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@janiscommerce/active-client": "^1.3.0",
     "@janiscommerce/api": "^3.1.1",
     "sinon": "^7.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "@janiscommerce/active-client": "^1.3.0",
+    "@janiscommerce/active-client": "^1.2.1",
     "@janiscommerce/api": "^3.1.1",
     "sinon": "^7.3.2"
   }

--- a/tests/api-test-test.js
+++ b/tests/api-test-test.js
@@ -381,4 +381,27 @@ describe('APITest', async () => {
 		}
 	}]);
 
+	APITestCaller(APICompleteClass, [{
+		description: 'should set response code, body, headers and cookie with default client',
+		client: true,
+		before: () => {},
+		after: () => {},
+		request: {
+			endpoint: 'custom-endpoint',
+			data: { fooData: 1 },
+			pathParameters: [1, 2],
+			headers: { 'some-header': 123 },
+			cookies: { 'some-cookie': 321 }
+		},
+		getResponse: () => {
+			// do something great with the response received as a param
+		},
+		response: {
+			code: 200,
+			body: { a: 2 },
+			strictHeaders: { 'some-header': 123 },
+			strictCookies: { 'some-cookie': 321 }
+		}
+	}]);
+
 });

--- a/tests/api-test-test.js
+++ b/tests/api-test-test.js
@@ -381,26 +381,37 @@ describe('APITest', async () => {
 		}
 	}]);
 
-	APITestCaller(APICompleteClass, [{
-		description: 'should set response code, body, headers and cookie with default client',
+
+	class APIClientClass extends API {
+
+		async process() {
+			this
+				.setBody({ clientName: this.client.name })
+				.setCode(200);
+		}
+	}
+
+	APITestCaller(APIClientClass, [{
+		description: 'should set response code and body with default client name',
 		client: true,
-		before: () => {},
-		after: () => {},
 		request: {
-			endpoint: 'custom-endpoint',
-			data: { fooData: 1 },
-			pathParameters: [1, 2],
-			headers: { 'some-header': 123 },
-			cookies: { 'some-cookie': 321 }
-		},
-		getResponse: () => {
-			// do something great with the response received as a param
+			endpoint: 'custom-endpoint'
 		},
 		response: {
 			code: 200,
-			body: { a: 2 },
-			strictHeaders: { 'some-header': 123 },
-			strictCookies: { 'some-cookie': 321 }
+			body: { clientName: 'defaultClient' }
+		}
+	}]);
+
+	APITestCaller(APIClientClass, [{
+		description: 'should set response code, body with current injected client name',
+		client: { id: 2, name: 'newClient' },
+		request: {
+			endpoint: 'custom-endpoint'
+		},
+		response: {
+			code: 200,
+			body: { clientName: 'newClient' }
 		}
 	}]);
 


### PR DESCRIPTION
**Branch**: JMV-457-add-defualt-client

Se agrego un client default para poder testear apis de clientes y se mantiene la posibilidad de mandar un objecto con las propiedades del cliente