### PR TITLE
change deepEqual to deepStrictEqual

### DIFF
--- a/lib/api-test.js
+++ b/lib/api-test.js
@@ -108,28 +108,28 @@ class APITest {
 		if(rule.getResponse)
 			rule.getResponse(response);
 
-		assert.deepEqual(response.code, rule.response.code, 'Unexpected response code');
+		assert.deepStrictEqual(response.code, rule.response.code, 'Unexpected response code');
 
 		if(rule.response.body)
-			assert.deepEqual(response.body, rule.response.body, 'Unexpected response body');
+			assert.deepStrictEqual(response.body, rule.response.body, 'Unexpected response body');
 
 		if(rule.response.strictHeaders)
-			assert.deepEqual(response.headers, rule.response.strictHeaders, 'Unexpected response headers');
+			assert.deepStrictEqual(response.headers, rule.response.strictHeaders, 'Unexpected response headers');
 
 		if(rule.response.headers) {
 			Object.entries(rule.response.headers).forEach(([name, value]) => {
 				assert(typeof response.headers[name] !== 'undefined', `Header '${name}' not found in response`);
-				assert.deepEqual(response.headers[name], value, `Header '${name}' value not equal`);
+				assert.deepStrictEqual(response.headers[name], value, `Header '${name}' value not equal`);
 			});
 		}
 
 		if(rule.response.strictCookies)
-			assert.deepEqual(response.cookies, rule.response.strictCookies, 'Unexpected response cookies');
+			assert.deepStrictEqual(response.cookies, rule.response.strictCookies, 'Unexpected response cookies');
 
 		if(rule.response.cookies) {
 			Object.entries(rule.response.cookies).forEach(([name, value]) => {
 				assert(typeof response.cookies[name] !== 'undefined', `Cookie '${name}' not found in response`);
-				assert.deepEqual(response.cookies[name], value, `Cookie '${name}' value not equal`);
+				assert.deepStrictEqual(response.cookies[name], value, `Cookie '${name}' value not equal`);
 			});
 		}
 


### PR DESCRIPTION
Según la recomendación del modulo en NodeJS deepEqual tiene stability 0 con lo cual se considera deprecado actualmente por lo cual se propone realizar el cambio a deepStrictEqual con lo cual se pueden prevenir errores futuros.

Se solicita estudiar el caso, para mayor información de lo propuesto en el pull request:
https://nodejs.org/api/assert.html#assert_assert_deepequal_actual_expected_message
